### PR TITLE
Feature: Moderated Channels

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -9,6 +9,18 @@
   --todo-bg-form-rgb: 153, 102, 204!important;
   --todo-bg-item-rgb: 102, 153, 204!important;
   --todo-bg-alpha: 0.35!important;
+
+  --purple-0: #f6f2ff;
+  --purple-10: #e2d4ff;
+  --purple-20: #ccb0ff;
+  --purple-30: #b68cff;
+  --purple-40: #a269ff;
+  --purple-50: #9146ff;
+  --purple-60: #8331f5;
+  --purple-70: #721de0;
+  --purple-75: #6f42c1;
+  --purple-80: #5e0cc2;
+  --purple-90: #470099;
 }
 
 .text-purple-0 {color: #f6f2ff;}

--- a/src/api/twitch/__snapshots__/twitch-api.test.js.snap
+++ b/src/api/twitch/__snapshots__/twitch-api.test.js.snap
@@ -72,7 +72,7 @@ exports[`TwitchApi > setAuthentication > should save oauth tokens and expiry tim
 ]
 `;
 
-exports[`TwitchApi > setStreamerInfo > should save streamer info to localStorage 1`] = `
+exports[`TwitchApi > setUserInfo > should save streamer info to localStorage 1`] = `
 [
   [
     "__channel",

--- a/src/api/twitch/index.js
+++ b/src/api/twitch/index.js
@@ -380,16 +380,13 @@ export default class TwitchApi {
   switchChannel = async(channel) => {
     try {
       this._channel = channel;
-      // let currChannel = await this._chatClient.getUsername();
-      // let resp = {};
-      // resp.part = await this._chatClient.part(currChannel);
-      // resp.join = await this._chatClient.join(channel);
-      // window.console.log('switchChannel - join', resp);
-      let channelInfo = await this.requestUserInfo({ login: channel });
+      const channelInfo = await this.requestUserInfo({ login: channel });
+      if (this.debug) {window.console.log('switchChannel', {channelInfo});}
       this.setChannelInfo(channelInfo.data[0]);
-      return await this.initChatClient();
+      await this._initChatClient();
+      return channelInfo;
     } catch (e) {
-      window.console.log('switchChannel - error', e);
+      window.console.error('switchChannel - error', e);
     }
   };
 

--- a/src/api/twitch/index.js
+++ b/src/api/twitch/index.js
@@ -37,9 +37,12 @@ export default class TwitchApi {
     this._authErrorCallback = authError ?? noop;
     this._expires_in = null;
     this._expiry_time = null;
+
     this._userInfo = {};
 
-    this._channel = null;
+    this._channel = null; // used when connected to a channel other than your own
+    this._channelInfo = {};
+
     this._onMessageCallback = onMessage ?? noop;
     this._chatClient = null;
     this._joinAccounced = [];
@@ -119,6 +122,8 @@ export default class TwitchApi {
   get isInit() {return this._isInit;}
 
   get channel() {return this._channel;}
+  get channelInfo() {return this._channelInfo;}
+
   get lastMessageTimes() {return this._lastMessageTimes;}
 
   _init = async() => {
@@ -146,7 +151,7 @@ export default class TwitchApi {
       localStorage.setItem('__channel', valid.login);
       let userInfo = users.data.filter(u => u.login === valid.login);
       if (userInfo.length === 1) {
-        this.setStreamerInfo(userInfo[0]);
+        this.setUserInfo(userInfo[0]);
       }
       if (this.debug) {window.console.log('TwitchApi - init: isInit');}
       this._isInit = true;
@@ -220,7 +225,7 @@ export default class TwitchApi {
       localStorage.setItem('__channel', valid.login);
       let userInfo = users.data.filter(u => u.login === valid.login);
       if (userInfo.length === 1) {
-        this.setStreamerInfo(userInfo[0]);
+        this.setUserInfo(userInfo[0]);
       }
       if (this.debug) {window.console.log('TwitchApi - resume: isInit');}
       this._isInit = true;
@@ -355,7 +360,7 @@ export default class TwitchApi {
     }
   };
 
-  setStreamerInfo = (userInfo) => {
+  setUserInfo = (userInfo) => {
     if (userInfo) {
       this._userInfo = userInfo;
       this._channel = userInfo.login;
@@ -366,6 +371,38 @@ export default class TwitchApi {
       localStorage.setItem('__profile_image_url', userInfo.profile_image_url);
     }
     return userInfo;
+  };
+
+  /**
+   * Leaves the current channel and joins the specified one
+   * @param {string} channel username of the channel to join
+   */
+  switchChannel = async(channel) => {
+    try {
+      this._channel = channel;
+      // let currChannel = await this._chatClient.getUsername();
+      // let resp = {};
+      // resp.part = await this._chatClient.part(currChannel);
+      // resp.join = await this._chatClient.join(channel);
+      // window.console.log('switchChannel - join', resp);
+      let channelInfo = await this.requestUserInfo({ login: channel });
+      this.setChannelInfo(channelInfo.data[0]);
+      return await this.initChatClient();
+    } catch (e) {
+      window.console.log('switchChannel - error', e);
+    }
+  };
+
+  setChannelInfo = (channelInfo) => {
+    if (channelInfo) {
+      this._channelInfo = channelInfo;
+      this._channel = channelInfo.login;
+      localStorage.setItem('__channel', channelInfo.login);
+      localStorage.setItem('__username', channelInfo.login);
+      localStorage.setItem('__user_id', channelInfo.id);
+      localStorage.setItem('__profile_image_url', channelInfo.profile_image_url);
+    }
+    return channelInfo;
   };
 
   requestAuthentication = async(code) => {
@@ -467,6 +504,32 @@ export default class TwitchApi {
     }
   };
 
+  /**
+   * Gets a list of channels that the specified user has moderator privileges in.
+   * https://dev.twitch.tv/docs/api/reference/#get-moderated-channels
+   * @param {string} id  A user’s ID. Returns the list of channels that this user has moderator privileges in. This ID must match the user ID in the user OAuth token
+   * @returns {Object[]} data		The list of channels that the user has moderator privileges in.
+   *  {string} broadcaster_id	String	An ID that uniquely identifies the channel this user can moderate.
+   *  {string} broadcaster_login	String	The channel’s login name.
+   *  {string} broadcaster_name	String	The channel’s display name.
+   */
+  requestModeratedChannels = async(id) => {
+    try {
+      const response = await fetch(`https://api.twitch.tv/helix/moderation/channels?user_id=${id}`, {
+        headers: {
+          'Client-ID': this._clientId,
+          Authorization: `Bearer ${this._accessToken}`
+        }
+      });
+      return await response.json();
+    } catch (error) {
+      if (this.debug) {window.console.log('TwitchApi - requestModeratedChannels: error', error);}
+      return await Promise.resolve(error);
+    }
+  };
+
+  // Gets all users allowed to moderate the broadcaster’s chat room.
+  // https://dev.twitch.tv/docs/api/reference/#get-moderators
   requestModerators = async(broadcasterId) => {
     try {
       const response = await fetch(`https://api.twitch.tv/helix/moderation/moderators?broadcaster_id=${broadcasterId}`, {
@@ -482,6 +545,34 @@ export default class TwitchApi {
     }
   };
 
+  /**
+   * Gets a list of the broadcaster’s VIPs.
+   * @param {string|number} broadcasterId  The ID of the broadcaster whose list of VIPs you want to get. This ID must match the user ID in the access token.
+   * @param {Array} userIds  Filters the list for specific VIPs. The maximum number of IDs that you may specify is 100. Ignores the ID of those users in the list that aren’t VIPs.
+   * @returns {Object[]} data  The list of VIPs. The list is empty if the broadcaster doesn’t have VIP users.
+   *  {string} user_id	String	An ID that uniquely identifies the VIP user.
+   *  {string} user_name	String	The user’s display name.
+   *  {string} user_login	String	The user’s login name.
+   */
+  requestVIPs = async(broadcasterId, userIds=null) => {
+    try {
+      if (!userIds || userIds.length === 0) {
+        userIds = '';
+      } else {
+        userIds = `&user_id=${userIds.join('&user_id=')}`;
+      }
+      const response = await fetch(`https://api.twitch.tv/helix/channels/vips?broadcaster_id=${broadcasterId}${userIds}`, {
+        headers: {
+          'Client-ID': this._clientId,
+          Authorization: `Bearer ${this._accessToken}`
+        }
+      });
+      return await response.json();
+    } catch (error) {
+      if (this.debug) {window.console.log('TwitchApi - requestVIPs: error', error);}
+      return await Promise.resolve(error);
+    }
+  };
 
   // https://dev.twitch.tv/docs/api/reference/#send-whisper
   // note: access token must include user:manage:whispers scope

--- a/src/api/twitch/index.js
+++ b/src/api/twitch/index.js
@@ -280,9 +280,9 @@ export default class TwitchApi {
     });
     this._chatClient.on('message', callback);
 
-    /*
+
     if (this.debug) {
-      this._chatClient.on('chat', (channel, userstate, message, self) => {
+      /*this._chatClient.on('chat', (channel, userstate, message, self) => {
         window.console.log('chatClient: chat', {channel, userstate, message, self});
       });
       this._chatClient.on('crash', (e) => {
@@ -329,9 +329,8 @@ export default class TwitchApi {
       });
       this._chatClient.on('ping', () => {
         if (this.debug) {window.console.log('chatClient: Ping!');}
-      });
+      });*/
     }
-    */
 
     await this._chatClient.connect();
     return this._chatClient;

--- a/src/api/twitch/twitch-api.test.js
+++ b/src/api/twitch/twitch-api.test.js
@@ -239,7 +239,7 @@ describe('TwitchApi', () => {
       vi.spyOn(twitchApi, 'requestUsers').mockResolvedValue({status: 204, data: [{login: 'username', id: 0}]});
       vi.spyOn(twitchApi, '_authErrorCallback').mockResolvedValue(void 0);
       vi.spyOn(twitchApi, '_onInitCallback').mockResolvedValue(void 0);
-      vi.spyOn(twitchApi, 'setStreamerInfo').mockResolvedValue(void 0);
+      vi.spyOn(twitchApi, 'setUserInfo').mockResolvedValue(void 0);
       vi.spyOn(twitchApi, 'initChatClient').mockResolvedValue(void 0);
     });
     test('should return oauth, users, and valid data', async() => {
@@ -317,7 +317,7 @@ describe('TwitchApi', () => {
       vi.spyOn(twitchApi, 'requestUsers').mockResolvedValue({status: 204, data: [{login: 'username', id: 0}]});
       vi.spyOn(twitchApi, '_authErrorCallback').mockResolvedValue(void 0);
       vi.spyOn(twitchApi, '_onInitCallback');
-      vi.spyOn(twitchApi, 'setStreamerInfo').mockResolvedValue(void 0);
+      vi.spyOn(twitchApi, 'setUserInfo').mockResolvedValue(void 0);
       vi.spyOn(twitchApi, 'initChatClient').mockResolvedValue(void 0);
     });
     test('should return oauth, users, and valid data', async() => {
@@ -487,10 +487,10 @@ describe('TwitchApi', () => {
     });
   });
 
-  describe('setStreamerInfo', () => {
+  describe('setUserInfo', () => {
     test('should save streamer info to localStorage', () => {
       vi.spyOn(window.localStorage.__proto__, 'setItem');
-      twitchApi.setStreamerInfo({
+      twitchApi.setUserInfo({
         login: 'login',
         id: 'id',
         profile_image_url: 'url'

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -10,7 +10,7 @@ const reducer = {
   counter: counterReducer,
   modal: modalCommandListReducer,
   // profile: profileReducer,
-  users: userReducer,
+  user: userReducer,
   todos: todosReducer,
 };
 export const store = configureStore({ reducer });

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,12 +2,14 @@ import {configureStore, ThunkAction, Action} from '@reduxjs/toolkit';
 import counterReducer from '@/features/redux-counter/counterSlice';
 import modalCommandListReducer from '@/features/modal-command-list/modalSlice';
 // import twitchReducer from '../features/twitch/twitchSlice';
+import channelReducer from '@/features/twitch/channel-slice.js';
 import userReducer from '@/features/player-queue/user-slice.js';
 // import { profileReducer } from '@/features/twitch/profileSlice';
 import todosReducer from '@/features/todos/todosSlice';
 
 const reducer = {
   counter: counterReducer,
+  channel: channelReducer,
   modal: modalCommandListReducer,
   // profile: profileReducer,
   user: userReducer,

--- a/src/components/main-screen/__snapshots__/main-screen.test.jsx.snap
+++ b/src/components/main-screen/__snapshots__/main-screen.test.jsx.snap
@@ -12,17 +12,30 @@ exports[`MainScreen > Should render without error 1`] = `
       <div
         class="container-fluid"
       >
-        <span
-          class="fw-semibold navbar-brand"
+        <div
+          class="dropdown"
+          id="dropdown-moderated-channels"
+          variant="link"
         >
-          <img
-            alt="dcpesses"
-            class="rounded-circle navbar-pfp-img"
-            src="profile_image-300x300.png"
-          />
-           
-          dcpesses
-        </span>
+          <button
+            aria-expanded="false"
+            class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+            id="dropdown-moderated-channels-toggle"
+            type="button"
+          >
+            <span
+              class="fw-semibold navbar-brand"
+            >
+              <img
+                alt="dcpesses"
+                class="rounded-circle navbar-pfp-img"
+                src="profile_image-300x300.png"
+              />
+               
+              dcpesses
+            </span>
+          </button>
+        </div>
         <button
           aria-controls="navbar-options-menu"
           aria-label="Toggle navigation"

--- a/src/components/main-screen/__snapshots__/main-screen.test.jsx.snap
+++ b/src/components/main-screen/__snapshots__/main-screen.test.jsx.snap
@@ -12,35 +12,22 @@ exports[`MainScreen > Should render without error 1`] = `
       <div
         class="container-fluid"
       >
-        <div
-          class="dropdown"
-          id="dropdown-moderated-channels"
-          variant="link"
+        <span
+          class="fw-semibold navbar-brand"
         >
-          <button
-            aria-expanded="false"
-            class="text-decoration-none text-white px-0 dropdown-toggle btn btn-link btn-sm"
-            id="dropdown-moderated-channels-toggle"
-            type="button"
-          >
-            <span
-              class="fw-semibold navbar-brand"
-            >
-              <img
-                alt="TwitchUser"
-                class="rounded-circle navbar-pfp-img proxy-profile-img"
-                src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
-              />
-              <img
-                alt="TwitchStreamer"
-                class="rounded-circle navbar-pfp-img"
-                src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
-              />
-               
-              TwitchStreamer
-            </span>
-          </button>
-        </div>
+          <img
+            alt="TwitchUser"
+            class="rounded-circle navbar-pfp-img proxy-profile-img"
+            src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+          />
+          <img
+            alt="TwitchStreamer"
+            class="rounded-circle navbar-pfp-img"
+            src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+          />
+           
+          TwitchStreamer
+        </span>
         <button
           aria-controls="navbar-options-menu"
           aria-label="Toggle navigation"
@@ -209,6 +196,33 @@ exports[`MainScreen > Should render without error 1`] = `
                       type="text"
                       value=""
                     />
+                  </button>
+                  <hr
+                    class="border-bottom my-2"
+                  />
+                  <h5>
+                    Beta Options
+                  </h5>
+                  <div
+                    class="smaller"
+                  >
+                    These options have not been fully tested and may not work as intended.
+                  </div>
+                  <button
+                    class="btn settings-menu btn btn-link"
+                    id="enable-moderated-channels-option"
+                    title="Allows user to use this app on another channel that grants them moderation access."
+                    type="button"
+                  >
+                    <input
+                      readonly=""
+                      role="switch"
+                      type="checkbox"
+                    />
+                     
+                    <span>
+                      Enable Moderated Channels Menu
+                    </span>
                   </button>
                 </div>
               </div>

--- a/src/components/main-screen/__snapshots__/main-screen.test.jsx.snap
+++ b/src/components/main-screen/__snapshots__/main-screen.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`MainScreen > Should render without error 1`] = `
         >
           <button
             aria-expanded="false"
-            class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+            class="text-decoration-none text-white px-0 dropdown-toggle btn btn-link btn-sm"
             id="dropdown-moderated-channels-toggle"
             type="button"
           >
@@ -27,12 +27,17 @@ exports[`MainScreen > Should render without error 1`] = `
               class="fw-semibold navbar-brand"
             >
               <img
-                alt="dcpesses"
+                alt="TwitchUser"
+                class="rounded-circle navbar-pfp-img proxy-profile-img"
+                src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+              />
+              <img
+                alt="TwitchStreamer"
                 class="rounded-circle navbar-pfp-img"
-                src="profile_image-300x300.png"
+                src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
               />
                
-              dcpesses
+              TwitchStreamer
             </span>
           </button>
         </div>

--- a/src/components/main-screen/index.jsx
+++ b/src/components/main-screen/index.jsx
@@ -10,7 +10,7 @@ import PlayerQueue from '@/features/player-queue';
 import ModalChangelog from '@/features/modal-changelog';
 import ModalCommandList from '@/features/modal-command-list';
 import { showModalCommandList } from '@/features/modal-command-list/modalSlice';
-import { setFakeStates, setUserInfo, setWhisperStatus } from '@/features/player-queue/user-slice.js';
+import { setFakeStates, setChatterInfo, setWhisperStatus } from '@/features/player-queue/user-slice.js';
 import * as fakeStates from '../twitch-wheel/example-states';
 
 import {version} from '../../../package.json';
@@ -125,7 +125,6 @@ class MainScreen extends Component {
         this.messageHandler.updateChatCommandTerm('leaveQueue', this.state.settings.customLeaveCommand);
       }
     }
-
   };
 
   initMessageHandler = () => {
@@ -334,7 +333,7 @@ class MainScreen extends Component {
       }));
       const userInfo = await this.twitchApi.requestUserInfo({login: user});
       if (userInfo?.data && userInfo?.data[0]) {
-        this.props.setUserInfo(userInfo.data[0]);
+        this.props.setChatterInfo(userInfo.data[0]);
       }
     }
   };
@@ -505,12 +504,12 @@ MainScreen.propTypes = {
   moderatedChannels: PropTypes.array,
   moderators: PropTypes.object,
   onLogOut: PropTypes.func,
+  setChatterInfo: PropTypes.func.isRequired,
   // profile_image_url: PropTypes.string,
   setFakeStates: PropTypes.func.isRequired,
-  setUserInfo: PropTypes.func.isRequired,
   setWhisperStatus: PropTypes.func.isRequired,
   showModalCommandList: PropTypes.func.isRequired,
-  twitchApi: PropTypes.object,
+  twitchApi: PropTypes.object.isRequired,
   // updateUsername: PropTypes.func,
   // userInfo: PropTypes.object,
   // user_id: PropTypes.any,
@@ -534,8 +533,8 @@ const mapStateToProps = state => ({
 });
 const mapDispatchToProps = () => ({
   showModalCommandList,
+  setChatterInfo,
   setFakeStates,
-  setUserInfo,
   setWhisperStatus,
 });
 export default connect(

--- a/src/components/main-screen/index.jsx
+++ b/src/components/main-screen/index.jsx
@@ -291,32 +291,6 @@ class MainScreen extends Component {
     }];
   };
 
-  getModeratedChannelsMenu = () => {
-    if (!this.props.moderatedChannels) {
-      return [];
-    }
-    return [{
-      broadcaster_id: this.twitchApi?.userInfo?.id,
-      broadcaster_login: this.twitchApi?.userInfo?.login,
-      broadcaster_name: this.twitchApi?.userInfo?.display_name,
-    }].concat(this.props.moderatedChannels).map(
-      channel => ({
-        label: channel.broadcaster_name,
-        onClick: async() => {
-          try {
-            console.log(`getModeratedChannelsMenu - ${channel.broadcaster_name} - calling twitchApi.switchChannel`);
-            await this.twitchApi?.switchChannel(channel.broadcaster_login);
-            console.log(`getModeratedChannelsMenu - ${channel.broadcaster_name} - success`);
-            return this.setState({
-              activeChannel: channel.broadcaster_login
-            });
-          } catch (e) {
-            console.log(`getModeratedChannelsMenu - ${channel.broadcaster_name} - error`, e);
-          }
-        }
-      })
-    );
-  };
 
   handleOpenModalCommandList = () => {
     if (this.props.showModalCommandList) {
@@ -462,8 +436,6 @@ class MainScreen extends Component {
           parentState={this.state}
           debugItems={this.getOptionsDebugMenu()}
           items={this.getOptionsMenu()}
-          moderatedChannelsItems={this.getModeratedChannelsMenu()}
-          moderatedChannels={this.props.moderatedChannels}
           reloadGameList={this.messageHandler?.reloadGameList}
           onHide={this.toggleOptionsMenu}
           onLogout={this.props.onLogOut}
@@ -501,7 +473,6 @@ class MainScreen extends Component {
 MainScreen.propTypes = {
   access_token: PropTypes.string,
   channel: PropTypes.string,
-  moderatedChannels: PropTypes.array,
   moderators: PropTypes.object,
   onLogOut: PropTypes.func,
   setChatterInfo: PropTypes.func.isRequired,
@@ -518,7 +489,6 @@ MainScreen.propTypes = {
 MainScreen.defaultProps = {
   access_token: null,
   channel: null,
-  moderatedChannels: null,
   moderators: null,
   onLogOut: null,
   profile_image_url: null,
@@ -529,7 +499,8 @@ MainScreen.defaultProps = {
   username: null,
 };
 const mapStateToProps = state => ({
-  modal: state.modal
+  modal: state.modal,
+  user: state.user
 });
 const mapDispatchToProps = () => ({
   showModalCommandList,

--- a/src/components/main-screen/main-screen.test.jsx
+++ b/src/components/main-screen/main-screen.test.jsx
@@ -13,24 +13,75 @@ vi.mock('../../../package.json', () => {
   };
 });
 
+const storeState = {
+  channel: {
+    user: {
+      id: '1',
+      login: 'twitchstreamer',
+      display_name: 'TwitchStreamer',
+      type: '',
+      broadcaster_type: '',
+      description: 'description',
+      profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+      offline_image_url: '',
+      view_count: 0,
+      created_at: '2019-11-18T00:47:34Z'
+    },
+    moderators: [{
+    }],
+    vips:[{
+    }],
+  },
+  user: {
+    info: {
+      id: '0',
+      login: 'twitchuser',
+      display_name: 'TwitchUser',
+      type: '',
+      broadcaster_type: '',
+      description: 'description',
+      profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+      offline_image_url: '',
+      view_count: 0,
+      created_at: '2019-11-18T00:47:34Z'
+    },
+    chatters: {
+      twitchuser: {
+        id: '0',
+        login: 'twitchuser',
+        display_name: 'TwitchUser',
+        type: '',
+        broadcaster_type: '',
+        description: 'description',
+        profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+        offline_image_url: '',
+        view_count: 0,
+        created_at: '2019-11-18T00:47:34Z'
+      }
+    },
+    moderatedChannels: [{
+      broadcaster_id: '1',
+      broadcaster_login: 'TwitchStreamer',
+      broadcaster_name: 'twitchstreamer',
+    }],
+    whisperStatus: {
+      twitchuser: {
+        login: 'twitchuser',
+        response: {
+          msg: 'Code sent to @TwitchUser',
+          status: 204
+        }
+      },
+    }
+  }
+};
+
 describe('MainScreen', () => {
   let store;
   let twitchApi;
   beforeEach(() => {
-    store = getStoreWithState();
+    store = getStoreWithState(storeState);
     twitchApi = {
-      userInfo: {
-        id: '473294395',
-        login: 'dcpesses',
-        display_name: 'dcpesses',
-        type: '',
-        broadcaster_type: '',
-        description: 'Don\'t mind me, I\'m just here for the Jackbox games and to support my peeps. ',
-        profile_image_url: 'profile_image-300x300.png',
-        offline_image_url: '',
-        view_count: 0,
-        created_at: '2019-11-18T10:47:34Z'
-      },
       debug: true
     };
   });

--- a/src/components/twitch-wheel/example-states.js
+++ b/src/components/twitch-wheel/example-states.js
@@ -5,7 +5,7 @@ const generateMockUserInfo = (max) => {
     bdate.setFullYear(bdate.getFullYear() - n);
 
     return {
-      info: {
+      chatters: {
         [`player${n}`]: {
           broadcaster_type: '',
           created_at: bdate.toISOString(),
@@ -48,7 +48,7 @@ const generateMockUserInfo = (max) => {
     };
   });
   return {
-    info: Object.assign({}, ...players.map(p => p.info)),
+    chatters: Object.assign({}, ...players.map(p => p.chatters)),
     lookup: Object.assign({}, ...players.map(p => p.lookup)),
   };
 };
@@ -640,7 +640,7 @@ const statePlayerSelect = {
 };
 
 const stateUserStore = {
-  info: Object.assign({
+  chatters: Object.assign({
     dcpesses: {
       'id': '0',
       'login': 'dcpesses',
@@ -653,7 +653,7 @@ const stateUserStore = {
       'view_count': 0,
       'created_at': '2019-11-18T00:47:34Z'
     }
-  }, mockPlayers.info),
+  }, mockPlayers.chatters),
   'whisperStatus': {
     'player1': {
       'login': 'player1',

--- a/src/components/twitch-wheel/header-menu/__snapshots__/header-menu.test.jsx.snap
+++ b/src/components/twitch-wheel/header-menu/__snapshots__/header-menu.test.jsx.snap
@@ -16,7 +16,7 @@ exports[`HeaderMenu > Should render without error 1`] = `
       >
         <button
           aria-expanded="false"
-          class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+          class="text-decoration-none text-white px-0 dropdown-toggle btn btn-link btn-sm"
           id="dropdown-moderated-channels-toggle"
           type="button"
         >
@@ -24,12 +24,17 @@ exports[`HeaderMenu > Should render without error 1`] = `
             class="fw-semibold navbar-brand"
           >
             <img
-              alt="dcpesses"
+              alt="TwitchUser"
+              class="rounded-circle navbar-pfp-img proxy-profile-img"
+              src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+            />
+            <img
+              alt="TwitchStreamer"
               class="rounded-circle navbar-pfp-img"
-              src="profile_image-300x300.png"
+              src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
             />
              
-            dcpesses
+            TwitchStreamer
           </span>
         </button>
       </div>
@@ -261,7 +266,7 @@ exports[`HeaderMenu > Should render without error 2`] = `
       >
         <button
           aria-expanded="false"
-          class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+          class="text-decoration-none text-white px-0 dropdown-toggle btn btn-link btn-sm"
           id="dropdown-moderated-channels-toggle"
           type="button"
         >
@@ -269,12 +274,17 @@ exports[`HeaderMenu > Should render without error 2`] = `
             class="fw-semibold navbar-brand"
           >
             <img
-              alt="dcpesses"
+              alt="TwitchUser"
+              class="rounded-circle navbar-pfp-img proxy-profile-img"
+              src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+            />
+            <img
+              alt="TwitchStreamer"
               class="rounded-circle navbar-pfp-img"
-              src="profile_image-300x300.png"
+              src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
             />
              
-            dcpesses
+            TwitchStreamer
           </span>
         </button>
       </div>
@@ -311,7 +321,7 @@ exports[`HeaderMenu > Should render without error 3`] = `
       >
         <button
           aria-expanded="false"
-          class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+          class="text-decoration-none text-white px-0 dropdown-toggle btn btn-link btn-sm"
           id="dropdown-moderated-channels-toggle"
           type="button"
         >
@@ -319,12 +329,17 @@ exports[`HeaderMenu > Should render without error 3`] = `
             class="fw-semibold navbar-brand"
           >
             <img
-              alt="dcpesses"
+              alt="TwitchUser"
+              class="rounded-circle navbar-pfp-img proxy-profile-img"
+              src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+            />
+            <img
+              alt="TwitchStreamer"
               class="rounded-circle navbar-pfp-img"
-              src="profile_image-300x300.png"
+              src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
             />
              
-            dcpesses
+            TwitchStreamer
           </span>
         </button>
       </div>

--- a/src/components/twitch-wheel/header-menu/__snapshots__/header-menu.test.jsx.snap
+++ b/src/components/twitch-wheel/header-menu/__snapshots__/header-menu.test.jsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`HeaderMenu > Should render without error 1`] = `
+exports[`HeaderMenu > Should render with moderated channels menu 1`] = `
 <div>
   <nav
     class="bg-body-tertiary mb-3 py-0 raleway-font navbar navbar-light"
@@ -205,6 +205,33 @@ exports[`HeaderMenu > Should render without error 1`] = `
                     value=""
                   />
                 </button>
+                <hr
+                  class="border-bottom my-2"
+                />
+                <h5>
+                  Beta Options
+                </h5>
+                <div
+                  class="smaller"
+                >
+                  These options have not been fully tested and may not work as intended.
+                </div>
+                <button
+                  class="btn settings-menu btn btn-link"
+                  id="enable-moderated-channels-option"
+                  title="Allows user to use this app on another channel that grants them moderation access."
+                  type="button"
+                >
+                  <input
+                    readonly=""
+                    role="switch"
+                    type="checkbox"
+                  />
+                   
+                  <span>
+                    Enable Moderated Channels Menu
+                  </span>
+                </button>
               </div>
             </div>
             <a
@@ -250,7 +277,7 @@ exports[`HeaderMenu > Should render without error 1`] = `
 </div>
 `;
 
-exports[`HeaderMenu > Should render without error 2`] = `
+exports[`HeaderMenu > Should render with moderated channels menu 2`] = `
 <div>
   <nav
     class="bg-body-tertiary mb-3 py-0 raleway-font navbar navbar-light"
@@ -305,7 +332,7 @@ exports[`HeaderMenu > Should render without error 2`] = `
 </div>
 `;
 
-exports[`HeaderMenu > Should render without error 3`] = `
+exports[`HeaderMenu > Should render with moderated channels menu 3`] = `
 <div>
   <nav
     class="bg-body-tertiary mb-3 py-0 raleway-font navbar navbar-light"
@@ -343,6 +370,354 @@ exports[`HeaderMenu > Should render without error 3`] = `
           </span>
         </button>
       </div>
+      <button
+        aria-controls="navbar-options-menu"
+        aria-label="Toggle navigation"
+        class="border-0 rounded-0 navbar-toggler"
+        data-margin-right=""
+        style=""
+        type="button"
+      >
+        <span
+          class="navbar-toggler-icon"
+        />
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`HeaderMenu > Should render without error 1`] = `
+<div>
+  <nav
+    class="bg-body-tertiary mb-3 py-0 raleway-font navbar navbar-light"
+    data-bs-theme="dark"
+  >
+    <div
+      class="container-fluid"
+    >
+      <span
+        class="fw-semibold navbar-brand"
+      >
+        <img
+          alt="TwitchUser"
+          class="rounded-circle navbar-pfp-img proxy-profile-img"
+          src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+        />
+        <img
+          alt="TwitchStreamer"
+          class="rounded-circle navbar-pfp-img"
+          src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+        />
+         
+        TwitchStreamer
+      </span>
+      <button
+        aria-controls="navbar-options-menu"
+        aria-label="Toggle navigation"
+        class="border-0 rounded-0 navbar-toggler collapsed"
+        type="button"
+      >
+        <span
+          class="navbar-toggler-icon"
+        />
+      </button>
+      <div
+        aria-labelledby="navbar-options-menu-label"
+        class="raleway-font offcanvas offcanvas-end"
+        id="navbar-options-menu"
+      >
+        <div
+          class="offcanvas-header"
+        >
+          <div
+            class="fw-bold fs-4 offcanvas-title h5"
+            id="navbar-options-menu-label"
+          >
+            Options
+          </div>
+          <button
+            aria-label="Close"
+            class="btn-close"
+            type="button"
+          />
+        </div>
+        <div
+          class="fw-medium offcanvas-body"
+        >
+          <div
+            class="justify-content-end flex-grow-1 pe-3 fs-5 navbar-nav"
+          >
+            <a
+              class="nav-link"
+              href="#"
+              role="button"
+              tabindex="0"
+            >
+              Logout
+            </a>
+            <hr
+              class="border-bottom my-2"
+            />
+            <a
+              class="settings-menu nav-link"
+              href="#"
+              role="button"
+              tabindex="0"
+            >
+              Settings
+            </a>
+            <div
+              class="accordion-dark accordion accordion-flush collapse"
+              id="settings-menu"
+            >
+              <div
+                class="accordion-body"
+              >
+                <button
+                  class="btn settings-menu btn btn-link"
+                  id="enable-room-code"
+                  title="Allows host to set a room code that can be whispered to players."
+                  type="button"
+                >
+                  <input
+                    readonly=""
+                    role="switch"
+                    type="checkbox"
+                  />
+                   
+                  <span>
+                    Enable Room Code
+                  </span>
+                </button>
+                <button
+                  class="btn settings-menu btn btn-link"
+                  title="Replaces the !join command with a custom term to use to join the Interested queue."
+                  type="button"
+                >
+                  <span
+                    for="custom-join-command"
+                  >
+                    Use Custom Join Command: 
+                  </span>
+                  <input
+                    class="form-control"
+                    id="custom-join-command"
+                    name="custom-join-command"
+                    placeholder="e.g. !join"
+                    spellcheck="false"
+                    type="text"
+                    value=""
+                  />
+                </button>
+                <button
+                  class="btn settings-menu btn btn-link"
+                  title="Messages users in chat when they've successfully joined the Interested queue."
+                  type="button"
+                >
+                  <input
+                    readonly=""
+                    role="switch"
+                    type="checkbox"
+                  />
+                   
+                  <span>
+                    Show Join Confirmation Message
+                  </span>
+                </button>
+                <button
+                  class="btn settings-menu btn btn-link"
+                  title="Replaces the !leave command with a custom term to use to leave all of the queues."
+                  type="button"
+                >
+                  <span
+                    for="custom-leave-command"
+                  >
+                    Use Custom Leave Command: 
+                  </span>
+                  <input
+                    class="form-control"
+                    id="custom-leave-command"
+                    name="custom-leave-command"
+                    placeholder="e.g. !leave"
+                    spellcheck="false"
+                    type="text"
+                    value=""
+                  />
+                </button>
+                <button
+                  class="btn settings-menu btn btn-link"
+                  title="Messages users in chat when they've successfully left the queues."
+                  type="button"
+                >
+                  <input
+                    readonly=""
+                    role="switch"
+                    type="checkbox"
+                  />
+                   
+                  <span>
+                    Show Leave Confirmation Message
+                  </span>
+                </button>
+                <button
+                  class="btn settings-menu btn btn-link"
+                  title="Uses a custom character or emote to separate requests listed in the chat."
+                  type="button"
+                >
+                  <span
+                    for="custom-delimiter"
+                  >
+                    Use Custom Delimiter: 
+                  </span>
+                  <input
+                    class="form-control"
+                    id="custom-delimiter"
+                    name="custom-delimiter"
+                    spellcheck="false"
+                    type="text"
+                    value=""
+                  />
+                </button>
+                <hr
+                  class="border-bottom my-2"
+                />
+                <h5>
+                  Beta Options
+                </h5>
+                <div
+                  class="smaller"
+                >
+                  These options have not been fully tested and may not work as intended.
+                </div>
+                <button
+                  class="btn settings-menu btn btn-link"
+                  id="enable-moderated-channels-option"
+                  title="Allows user to use this app on another channel that grants them moderation access."
+                  type="button"
+                >
+                  <input
+                    readonly=""
+                    role="switch"
+                    type="checkbox"
+                  />
+                   
+                  <span>
+                    Enable Moderated Channels Menu
+                  </span>
+                </button>
+              </div>
+            </div>
+            <a
+              class="nav-link"
+              href="#"
+              role="button"
+              tabindex="0"
+            >
+              View Chat Commands
+            </a>
+            <a
+              class="nav-link"
+              href="#"
+              role="button"
+              tabindex="0"
+            >
+              Changelog
+            </a>
+            <div
+              class="position-absolute bottom-0 start-0 end-0 pb-3 text-center"
+              id="options-debug-menu-items"
+            >
+              <div
+                class="dropup-center dropup"
+                id="dropdown-debug-menu-items"
+                variant="link"
+              >
+                <button
+                  aria-expanded="false"
+                  class="text-decoration-none dropdown-toggle btn btn-link btn-sm"
+                  id="dropdown-debug-menu-items-toggle"
+                  type="button"
+                >
+                  version 0.0.0
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`HeaderMenu > Should render without error 2`] = `
+<div>
+  <nav
+    class="bg-body-tertiary mb-3 py-0 raleway-font navbar navbar-light"
+    data-bs-theme="dark"
+  >
+    <div
+      class="container-fluid"
+    >
+      <span
+        class="fw-semibold navbar-brand"
+      >
+        <img
+          alt="TwitchUser"
+          class="rounded-circle navbar-pfp-img proxy-profile-img"
+          src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+        />
+        <img
+          alt="TwitchStreamer"
+          class="rounded-circle navbar-pfp-img"
+          src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+        />
+         
+        TwitchStreamer
+      </span>
+      <button
+        aria-controls="navbar-options-menu"
+        aria-label="Toggle navigation"
+        class="border-0 rounded-0 navbar-toggler"
+        data-margin-right=""
+        style=""
+        type="button"
+      >
+        <span
+          class="navbar-toggler-icon"
+        />
+      </button>
+    </div>
+  </nav>
+</div>
+`;
+
+exports[`HeaderMenu > Should render without error 3`] = `
+<div>
+  <nav
+    class="bg-body-tertiary mb-3 py-0 raleway-font navbar navbar-light"
+    data-bs-theme="dark"
+  >
+    <div
+      class="container-fluid"
+    >
+      <span
+        class="fw-semibold navbar-brand"
+      >
+        <img
+          alt="TwitchUser"
+          class="rounded-circle navbar-pfp-img proxy-profile-img"
+          src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+        />
+        <img
+          alt="TwitchStreamer"
+          class="rounded-circle navbar-pfp-img"
+          src="https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png"
+        />
+         
+        TwitchStreamer
+      </span>
       <button
         aria-controls="navbar-options-menu"
         aria-label="Toggle navigation"

--- a/src/components/twitch-wheel/header-menu/__snapshots__/header-menu.test.jsx.snap
+++ b/src/components/twitch-wheel/header-menu/__snapshots__/header-menu.test.jsx.snap
@@ -9,17 +9,30 @@ exports[`HeaderMenu > Should render without error 1`] = `
     <div
       class="container-fluid"
     >
-      <span
-        class="fw-semibold navbar-brand"
+      <div
+        class="dropdown"
+        id="dropdown-moderated-channels"
+        variant="link"
       >
-        <img
-          alt="dcpesses"
-          class="rounded-circle navbar-pfp-img"
-          src="profile_image-300x300.png"
-        />
-         
-        dcpesses
-      </span>
+        <button
+          aria-expanded="false"
+          class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+          id="dropdown-moderated-channels-toggle"
+          type="button"
+        >
+          <span
+            class="fw-semibold navbar-brand"
+          >
+            <img
+              alt="dcpesses"
+              class="rounded-circle navbar-pfp-img"
+              src="profile_image-300x300.png"
+            />
+             
+            dcpesses
+          </span>
+        </button>
+      </div>
       <button
         aria-controls="navbar-options-menu"
         aria-label="Toggle navigation"
@@ -241,17 +254,30 @@ exports[`HeaderMenu > Should render without error 2`] = `
     <div
       class="container-fluid"
     >
-      <span
-        class="fw-semibold navbar-brand"
+      <div
+        class="dropdown"
+        id="dropdown-moderated-channels"
+        variant="link"
       >
-        <img
-          alt="dcpesses"
-          class="rounded-circle navbar-pfp-img"
-          src="profile_image-300x300.png"
-        />
-         
-        dcpesses
-      </span>
+        <button
+          aria-expanded="false"
+          class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+          id="dropdown-moderated-channels-toggle"
+          type="button"
+        >
+          <span
+            class="fw-semibold navbar-brand"
+          >
+            <img
+              alt="dcpesses"
+              class="rounded-circle navbar-pfp-img"
+              src="profile_image-300x300.png"
+            />
+             
+            dcpesses
+          </span>
+        </button>
+      </div>
       <button
         aria-controls="navbar-options-menu"
         aria-label="Toggle navigation"
@@ -278,17 +304,30 @@ exports[`HeaderMenu > Should render without error 3`] = `
     <div
       class="container-fluid"
     >
-      <span
-        class="fw-semibold navbar-brand"
+      <div
+        class="dropdown"
+        id="dropdown-moderated-channels"
+        variant="link"
       >
-        <img
-          alt="dcpesses"
-          class="rounded-circle navbar-pfp-img"
-          src="profile_image-300x300.png"
-        />
-         
-        dcpesses
-      </span>
+        <button
+          aria-expanded="false"
+          class="text-decoration-none text-white dropdown-toggle btn btn-link btn-sm"
+          id="dropdown-moderated-channels-toggle"
+          type="button"
+        >
+          <span
+            class="fw-semibold navbar-brand"
+          >
+            <img
+              alt="dcpesses"
+              class="rounded-circle navbar-pfp-img"
+              src="profile_image-300x300.png"
+            />
+             
+            dcpesses
+          </span>
+        </button>
+      </div>
       <button
         aria-controls="navbar-options-menu"
         aria-label="Toggle navigation"

--- a/src/components/twitch-wheel/header-menu/header-menu.css
+++ b/src/components/twitch-wheel/header-menu/header-menu.css
@@ -2,6 +2,25 @@ nav .navbar-pfp-img {
   height: 28px;
   width: 28px;
 }
+nav .navbar-pfp-img.proxy-profile-img {
+  height: 19px;
+  width: 19px;
+  position: absolute;
+  margin-top: 16px;
+  margin-left: 16px;
+  border: 1px solid var(--purple-30);
+  /* box-shadow: 0px 0px 5px var(--purple-10)!important; */
+}
+
+#dropdown-moderated-channels .dropdown-item {
+  font-size: 14px!important;
+  font-weight: 500!important;
+}
+
+#dropdown-moderated-channels .dropdown-menu-dark {
+  --bs-dropdown-link-active-bg: var(--bs-secondary-bg-subtle)!important;
+}
+
 
 #navbar-options-menu .offcanvas-body {
   padding-left: calc(var(--bs-offcanvas-padding-x) * 1.75);

--- a/src/components/twitch-wheel/header-menu/header-menu.test.jsx
+++ b/src/components/twitch-wheel/header-menu/header-menu.test.jsx
@@ -1,5 +1,7 @@
 /* eslint-env jest */
 import {vi} from 'vitest';
+import { Provider } from 'react-redux';
+import { getStoreWithState } from '@/app/store';
 import { fireEvent, render, screen } from '@testing-library/react';
 import HeaderMenu from './index';
 
@@ -9,10 +11,78 @@ vi.mock('../../../../package.json', () => {
     version: '0.0.0'
   };
 });
+const storeState = {
+  channel: {
+    user: {
+      id: '1',
+      login: 'twitchstreamer',
+      display_name: 'TwitchStreamer',
+      type: '',
+      broadcaster_type: '',
+      description: 'description',
+      profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+      offline_image_url: '',
+      view_count: 0,
+      created_at: '2019-11-18T00:47:34Z'
+    },
+    moderators: [{
+    }],
+    vips:[{
+    }],
+  },
+  modal: {
+    visible: false
+  },
+  user: {
+    info: {
+      id: '0',
+      login: 'twitchuser',
+      display_name: 'TwitchUser',
+      type: '',
+      broadcaster_type: '',
+      description: 'description',
+      profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+      offline_image_url: '',
+      view_count: 0,
+      created_at: '2019-11-18T00:47:34Z'
+    },
+    chatters: {
+      twitchuser: {
+        id: '0',
+        login: 'twitchuser',
+        display_name: 'TwitchUser',
+        type: '',
+        broadcaster_type: '',
+        description: 'description',
+        profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+        offline_image_url: '',
+        view_count: 0,
+        created_at: '2019-11-18T00:47:34Z'
+      }
+    },
+    moderatedChannels: [{
+      broadcaster_id: '1',
+      broadcaster_login: 'TwitchStreamer',
+      broadcaster_name: 'twitchstreamer',
+    }],
+    whisperStatus: {
+      twitchuser: {
+        login: 'twitchuser',
+        response: {
+          msg: 'Code sent to @TwitchUser',
+          status: 204
+        }
+      },
+    }
+  }
+};
+
 
 describe('HeaderMenu', () => {
+  let store;
   let props;
   beforeEach(()=>{
+    store = getStoreWithState(storeState);
     props = {
       gamesList: {
         maxPlayersList: [4, 6, 7, 8, 9, 10, 12, 16, 20],
@@ -121,29 +191,26 @@ describe('HeaderMenu', () => {
       showOptionsMenu: false,
       twitchApi: {
         userInfo: {
-          id: '473294395',
-          login: 'dcpesses',
-          display_name: 'dcpesses',
+          id: '0',
+          login: 'twitchuser',
+          display_name: 'TwitchUser',
           type: '',
           broadcaster_type: '',
-          description: 'Don\'t mind me, I\'m just here for the Jackbox games and to support my peeps. ',
-          profile_image_url: 'profile_image-300x300.png',
+          description: 'description',
+          profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
           offline_image_url: '',
           view_count: 0,
-          created_at: '2019-11-18T10:47:34Z'
+          created_at: '2019-11-18T00:47:34Z'
         },
         debug: true
-      },
-      userInfo: {
-        username: '',
-        user_id: 0,
-        profile_image_url: null
       }
     };
   });
   test('Should render without error', () => {
     const {container} = render(
-      <HeaderMenu {...props} />
+      <Provider store={store}>
+        <HeaderMenu {...props} />
+      </Provider>
     );
     expect(container).toMatchSnapshot();
     fireEvent.click(screen.getByLabelText('Toggle navigation'));
@@ -156,5 +223,6 @@ describe('HeaderMenu', () => {
     // fireEvent.change(screen.getByRole('textbox', {name: 'Use Custom Delimiter:'}), {target: {value: ' | '}});
     // expect(container).toMatchSnapshot();
   });
+
 });
 

--- a/src/components/twitch-wheel/header-menu/header-menu.test.jsx
+++ b/src/components/twitch-wheel/header-menu/header-menu.test.jsx
@@ -184,6 +184,7 @@ describe('HeaderMenu', () => {
         { label: 'View Chat Commands' }
       ],
       settings: {
+        enableModeratedChannelsOption: false,
         enableRoomCode: true,
         enableSubRequests: false,
         customDelimiter: null
@@ -224,5 +225,18 @@ describe('HeaderMenu', () => {
     // expect(container).toMatchSnapshot();
   });
 
+  test('Should render with moderated channels menu', () => {
+    props.settings.enableModeratedChannelsOption = true;
+    const {container} = render(
+      <Provider store={store}>
+        <HeaderMenu {...props} />
+      </Provider>
+    );
+    expect(container).toMatchSnapshot();
+    fireEvent.click(screen.getByLabelText('Toggle navigation'));
+    expect(container).toMatchSnapshot();
+    fireEvent.click(screen.getByText('Settings', {selector: 'a.settings-menu'}));
+    expect(container).toMatchSnapshot();
+  });
 });
 

--- a/src/features/player-queue/player-queue-card.jsx
+++ b/src/features/player-queue/player-queue-card.jsx
@@ -33,15 +33,15 @@ function PlayerQueueCard({btnProps, onRemoveUser, onSendCode, queueName, priorit
   }
 
   // Merge user info with props data
-  const { info, whisperStatus } = useSelector((state) => state.users);
+  const { chatters, whisperStatus } = useSelector((state) => state.user);
   let userInfo = {};
   let display_name = username;
   let img = (
     <i className="bi-person-fill rounded-circle user-profile-image bg-secondary bg-gradient text-white-50" alt={display_name} />
   );
   let created_at, description, relativeCreatedAt;
-  if (info[username]) {
-    userInfo = info[username];
+  if (chatters[username]) {
+    userInfo = chatters[username];
     display_name = userInfo.display_name;
     if (userInfo?.profile_image_url) {
       img = (

--- a/src/features/player-queue/player-queue-card.test.jsx
+++ b/src/features/player-queue/player-queue-card.test.jsx
@@ -29,8 +29,8 @@ describe('PlayerQueueCard', () => {
 
   test('Should render as a user in the interested queue', () => {
     store = getStoreWithState({
-      users: {
-        info: {
+      user: {
+        chatters: {
           dcpesses: {
             id: '473294395',
             login: 'dcpesses',
@@ -78,8 +78,8 @@ describe('PlayerQueueCard', () => {
 
   test('Should render as a whispered user in the playing queue', () => {
     store = getStoreWithState({
-      users: {
-        info: {
+      user: {
+        chatters: {
           dcpesses: {
             id: '473294395',
             login: 'dcpesses',

--- a/src/features/player-queue/user-slice.js
+++ b/src/features/player-queue/user-slice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   chatters: {}, // user info for chatters
+  info: {},
   moderatedChannels: [],
   whisperStatus: {},
 };
@@ -11,6 +12,9 @@ export const userSlice = createSlice({
   name: 'user',
   initialState,
   reducers: {
+    clearUserInfo: (state) => {
+      state.info = {};
+    },
     setFakeStates: (state, action) => {
       if (action.payload.chatters) {
         state.chatters = action.payload.chatters;
@@ -27,6 +31,11 @@ export const userSlice = createSlice({
     setChatterInfo: (state, action) => {
       if (action.payload.login) {
         state.chatters[action.payload.login] = action.payload;
+      }
+    },
+    setUserInfo: (state, action) => {
+      if (action.payload.login) {
+        state.info = action.payload;
       }
     },
     setWhisperStatus: (state, action) => {
@@ -50,6 +59,6 @@ export const userSlice = createSlice({
   },
 });
 
-export const { setChatterInfo, setFakeStates, setModeratedChannels, setWhisperStatus, removeChatterInfo, removeModeratedChannels, removeWhisperStatus } = userSlice.actions;
+export const { clearUserInfo, setChatterInfo, setFakeStates, setModeratedChannels, setUserInfo, setWhisperStatus, removeChatterInfo, removeModeratedChannels, removeWhisperStatus } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/src/features/player-queue/user-slice.js
+++ b/src/features/player-queue/user-slice.js
@@ -1,26 +1,32 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  info: {},
-  whisperStatus: {}
+  chatters: {}, // user info for chatters
+  moderatedChannels: [],
+  whisperStatus: {},
 };
 
 
 export const userSlice = createSlice({
-  name: 'users',
+  name: 'user',
   initialState,
   reducers: {
     setFakeStates: (state, action) => {
-      if (action.payload.info) {
-        state.info = action.payload.info;
+      if (action.payload.chatters) {
+        state.chatters = action.payload.chatters;
       }
       if (action.payload.whisperStatus) {
         state.whisperStatus = action.payload.whisperStatus;
       }
     },
-    setUserInfo: (state, action) => {
+    setModeratedChannels: (state, action) => {
+      if (action.payload) {
+        state.moderatedChannels = action.payload;
+      }
+    },
+    setChatterInfo: (state, action) => {
       if (action.payload.login) {
-        state.info[action.payload.login] = action.payload;
+        state.chatters[action.payload.login] = action.payload;
       }
     },
     setWhisperStatus: (state, action) => {
@@ -28,9 +34,12 @@ export const userSlice = createSlice({
         state.whisperStatus[action.payload.login] = action.payload;
       }
     },
-    removeUserInfo: (state, action) => {
+    removeModeratedChannels: (state) => {
+      state.moderatedChannels = [];
+    },
+    removeChatterInfo: (state, action) => {
       if (action.payload) {
-        delete state.info[action.payload];
+        delete state.chatters[action.payload];
       }
     },
     removeWhisperStatus: (state, action) => {
@@ -41,6 +50,6 @@ export const userSlice = createSlice({
   },
 });
 
-export const { setFakeStates, setUserInfo, setWhisperStatus, removeUserInfo, removeWhisperStatus } = userSlice.actions;
+export const { setChatterInfo, setFakeStates, setModeratedChannels, setWhisperStatus, removeChatterInfo, removeModeratedChannels, removeWhisperStatus } = userSlice.actions;
 
 export default userSlice.reducer;

--- a/src/features/player-queue/user-slice.js
+++ b/src/features/player-queue/user-slice.js
@@ -30,18 +30,16 @@ export const userSlice = createSlice({
     },
     removeUserInfo: (state, action) => {
       if (action.payload) {
-        state.info[action.payload] = null;
+        delete state.info[action.payload];
       }
     },
     removeWhisperStatus: (state, action) => {
       if (action.payload) {
-        state.whisperStatus[action.payload] = null;
+        delete state.whisperStatus[action.payload];
       }
     },
   },
 });
-
-export const selectUser = (state) => state.users.info;
 
 export const { setFakeStates, setUserInfo, setWhisperStatus, removeUserInfo, removeWhisperStatus } = userSlice.actions;
 

--- a/src/features/player-queue/user-slice.spec.js
+++ b/src/features/player-queue/user-slice.spec.js
@@ -1,14 +1,16 @@
 /* eslint-env jest */
 import userReducer, {
   setFakeStates,
-  setUserInfo,
+  setModeratedChannels,
+  setChatterInfo,
   setWhisperStatus,
-  removeUserInfo,
+  removeModeratedChannels,
+  removeChatterInfo,
   removeWhisperStatus
 } from './user-slice';
 
 const userState = {
-  info: {
+  chatters: {
     twitchuser: {
       id: '0',
       login: 'twitchuser',
@@ -22,6 +24,11 @@ const userState = {
       created_at: '2019-11-18T00:47:34Z'
     }
   },
+  moderatedChannels: [{
+    broadcaster_id: '1',
+    broadcaster_login: 'TwitchStreamer',
+    broadcaster_name: 'twitchstreamer',
+  }],
   whisperStatus: {
     twitchuser: {
       login: 'twitchuser',
@@ -35,25 +42,27 @@ const userState = {
 
 describe('user reducer', () => {
   const initialState = {
-    info: {},
+    chatters: {},
+    moderatedChannels: [],
     whisperStatus: {}
   };
   it('should handle initial state', () => {
     expect(userReducer(undefined, { type: 'unknown' })).toEqual({
-      info: {},
+      chatters: {},
+      moderatedChannels: [],
       whisperStatus: {}
     });
   });
 
   it('should set the fake states', () => {
     const actual = userReducer(initialState, setFakeStates(userState));
-    expect(actual.info).toEqual(userState.info);
+    expect(actual.chatters).toEqual(userState.chatters);
     expect(actual.whisperStatus).toEqual(userState.whisperStatus);
   });
 
-  it('should set the user info for the given user', () => {
-    const actual = userReducer(initialState, setUserInfo(userState.info.twitchuser));
-    expect(actual.info.twitchuser).toEqual(userState.info.twitchuser);
+  it('should set the user chatters for the given user', () => {
+    const actual = userReducer(initialState, setChatterInfo(userState.chatters.twitchuser));
+    expect(actual.chatters.twitchuser).toEqual(userState.chatters.twitchuser);
   });
 
   it('should set the whisper status for the given user', () => {
@@ -61,13 +70,23 @@ describe('user reducer', () => {
     expect(actual.whisperStatus.twitchuser).toEqual(userState.whisperStatus.twitchuser);
   });
 
-  it('should remove the user info for the given user', () => {
-    const actual = userReducer(userState, removeUserInfo('twitchuser'));
-    expect(actual.info).toEqual(initialState.info);
+  it('should remove the user chatters for the given user', () => {
+    const actual = userReducer(userState, removeChatterInfo('twitchuser'));
+    expect(actual.chatters).toEqual(initialState.chatters);
   });
 
   it('should remove the whisper status for the given user', () => {
     const actual = userReducer(userState, removeWhisperStatus('twitchuser'));
     expect(actual.whisperStatus).toEqual(initialState.whisperStatus);
+  });
+
+  it('should update the list of moderated channels by merging the payload data', () => {
+    const actual = userReducer(initialState, setModeratedChannels(userState.moderatedChannels));
+    expect(actual.moderatedChannels).toEqual(userState.moderatedChannels);
+  });
+
+  it('should update the list of moderated channels by clearing all data', () => {
+    const actual = userReducer(initialState, removeModeratedChannels());
+    expect(actual.moderatedChannels).toEqual(initialState.moderatedChannels);
   });
 });

--- a/src/features/player-queue/user-slice.spec.js
+++ b/src/features/player-queue/user-slice.spec.js
@@ -43,12 +43,14 @@ const userState = {
 describe('user reducer', () => {
   const initialState = {
     chatters: {},
+    info: {},
     moderatedChannels: [],
     whisperStatus: {}
   };
   it('should handle initial state', () => {
     expect(userReducer(undefined, { type: 'unknown' })).toEqual({
       chatters: {},
+      info: {},
       moderatedChannels: [],
       whisperStatus: {}
     });

--- a/src/features/player-queue/user-slice.spec.js
+++ b/src/features/player-queue/user-slice.spec.js
@@ -1,0 +1,73 @@
+/* eslint-env jest */
+import userReducer, {
+  setFakeStates,
+  setUserInfo,
+  setWhisperStatus,
+  removeUserInfo,
+  removeWhisperStatus
+} from './user-slice';
+
+const userState = {
+  info: {
+    twitchuser: {
+      id: '0',
+      login: 'twitchuser',
+      display_name: 'TwitchUser',
+      type: '',
+      broadcaster_type: '',
+      description: 'description',
+      profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+      offline_image_url: '',
+      view_count: 0,
+      created_at: '2019-11-18T00:47:34Z'
+    }
+  },
+  whisperStatus: {
+    twitchuser: {
+      login: 'twitchuser',
+      response: {
+        msg: 'Code sent to @TwitchUser',
+        status: 204
+      }
+    },
+  }
+};
+
+describe('user reducer', () => {
+  const initialState = {
+    info: {},
+    whisperStatus: {}
+  };
+  it('should handle initial state', () => {
+    expect(userReducer(undefined, { type: 'unknown' })).toEqual({
+      info: {},
+      whisperStatus: {}
+    });
+  });
+
+  it('should set the fake states', () => {
+    const actual = userReducer(initialState, setFakeStates(userState));
+    expect(actual.info).toEqual(userState.info);
+    expect(actual.whisperStatus).toEqual(userState.whisperStatus);
+  });
+
+  it('should set the user info for the given user', () => {
+    const actual = userReducer(initialState, setUserInfo(userState.info.twitchuser));
+    expect(actual.info.twitchuser).toEqual(userState.info.twitchuser);
+  });
+
+  it('should set the whisper status for the given user', () => {
+    const actual = userReducer(initialState, setWhisperStatus(userState.whisperStatus.twitchuser));
+    expect(actual.whisperStatus.twitchuser).toEqual(userState.whisperStatus.twitchuser);
+  });
+
+  it('should remove the user info for the given user', () => {
+    const actual = userReducer(userState, removeUserInfo('twitchuser'));
+    expect(actual.info).toEqual(initialState.info);
+  });
+
+  it('should remove the whisper status for the given user', () => {
+    const actual = userReducer(userState, removeWhisperStatus('twitchuser'));
+    expect(actual.whisperStatus).toEqual(initialState.whisperStatus);
+  });
+});

--- a/src/features/twitch-messages/message-handler.js
+++ b/src/features/twitch-messages/message-handler.js
@@ -293,7 +293,7 @@ export default class MessageHandler {
     closeQueueHandler=noop,
     logUserMessages,
     messages,
-    modList,
+    moderators,
     onDelete=noop,
     onInit=noop,
     onMessageCallback=noop,
@@ -323,7 +323,7 @@ export default class MessageHandler {
     this.joinQueueHandler = joinQueueHandler;
     this.logUserMessages = logUserMessages;
     this.messages = messages;
-    this.modList = modList;
+    this.moderators = moderators;
     this.onDelete = onDelete;
     this._onInitCallback = onInit ?? noop;
     this.onMessageCallback = onMessageCallback;
@@ -385,7 +385,7 @@ export default class MessageHandler {
   };
 
   isModOrBroadcaster = (username) => {
-    return (this.channel === username.toLowerCase() || this.modList.includes(username.toLowerCase()));
+    return (this.channel === username.toLowerCase() || this.moderators.includes(username.toLowerCase()));
   };
 
   // returns true if a known command was found & responded to

--- a/src/features/twitch-messages/message-handler.test.js
+++ b/src/features/twitch-messages/message-handler.test.js
@@ -23,7 +23,7 @@ const getMessageHandlerConfig = (overrides={}) => Object.assign({
   joinQueueHandler: vi.fn(),
   logUserMessages: false,
   messages: {},
-  modList: [],
+  moderators: [],
   onDelete: vi.fn(),
   onMessageCallback: vi.fn(),
   onSettingsUpdate: vi.fn(),
@@ -315,7 +315,7 @@ describe('MessageHandler', () => {
     props = {
       access_token: 'blahblahblahblahblah',
       channel: 'sirfarewell',
-      modList: [
+      moderators: [
         'asukii314',
         'dcpesses'
       ],
@@ -394,7 +394,7 @@ describe('MessageHandler', () => {
       expect(messageHandler.logUserMessages).toBeUndefined();
       expect(messageHandler._isInit).toBeFalsy();
       expect(messageHandler.messages).toBeUndefined();
-      expect(messageHandler.modList).toBeUndefined();
+      expect(messageHandler.moderators).toBeUndefined();
       expect(messageHandler.onDelete).toBe(noop);
       expect(messageHandler.onMessageCallback).toBe(noop);
       expect(messageHandler.openQueueHandler).toBe(noop);
@@ -422,7 +422,7 @@ describe('MessageHandler', () => {
         joinQueueHandler: mockCallback,
         logUserMessages: false,
         messages: {},
-        modList: [],
+        moderators: [],
         onDelete: mockCallback,
         onMessageCallback: mockCallback,
         onSettingsUpdate: mockCallback,
@@ -451,7 +451,7 @@ describe('MessageHandler', () => {
       expect(messageHandler.debug).toBeFalsy();
       expect(messageHandler._isInit).toBeFalsy();
       expect(messageHandler.messages).toEqual({});
-      expect(messageHandler.modList).toEqual([]);
+      expect(messageHandler.moderators).toEqual([]);
       expect(messageHandler.onDelete).toBe(mockCallback);
       expect(messageHandler.onMessageCallback).toBe(mockCallback);
       expect(messageHandler.openQueueHandler).toBe(mockCallback);
@@ -489,7 +489,7 @@ describe('MessageHandler', () => {
     test('returns true only if the user is the channel host or mod', () => {
       messageHandler = new MessageHandler(getMessageHandlerConfig({
         channel: 'sirfarewell',
-        modList: [
+        moderators: [
           'dcpesses',
           'mockmoduser',
         ]

--- a/src/features/twitch/channel-slice.js
+++ b/src/features/twitch/channel-slice.js
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  user: {},
+  moderators: [],
+  vips: []
+};
+
+export const userSlice = createSlice({
+  name: 'channel',
+  initialState,
+  reducers: {
+    clearChannelInfo: (state) => {
+      state.user = {};
+    },
+    clearModerators: (state) => {
+      state.moderators = [];
+    },
+    clearVIPs: (state,) => {
+      state.vips = [];
+    },
+    setChannelInfo: (state, action) => {
+      if (action.payload.login) {
+        state.user = action.payload;
+      }
+    },
+    setModerators: (state, action) => {
+      if (action.payload) {
+        state.moderators = action.payload;
+      }
+    },
+    setVIPs: (state, action) => {
+      if (action.payload) {
+        state.vips = action.payload;
+      }
+    },
+  },
+});
+
+export const { clearChannelInfo, clearModerators, clearVIPs, setChannelInfo, setModerators, setVIPs } = userSlice.actions;
+
+export default userSlice.reducer;

--- a/src/features/twitch/channel-slice.spec.js
+++ b/src/features/twitch/channel-slice.spec.js
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+import userReducer, {
+  // setFakeStates,
+  clearChannelInfo,
+  clearModerators,
+  clearVIPs,
+  setChannelInfo,
+  setModerators,
+  setVIPs
+} from './channel-slice';
+
+const userState = {
+  user: {
+    id: '1',
+    login: 'twitchstreamer',
+    display_name: 'TwitchStreamer',
+    type: '',
+    broadcaster_type: '',
+    description: 'description',
+    profile_image_url: 'https://static-cdn.jtvnw.net/jtv_user_pictures/profile_image-300x300.png',
+    offline_image_url: '',
+    view_count: 0,
+    created_at: '2019-11-18T00:47:34Z'
+  },
+  moderators: [{
+  }],
+  vips:[{
+  }],
+};
+
+describe('channel reducer', () => {
+  const initialState = {
+    user: {},
+    moderators: [],
+    vips: []
+  };
+  it('should handle initial state', () => {
+    expect(userReducer(undefined, { type: 'unknown' })).toEqual({
+      user: {},
+      moderators: [],
+      vips: []
+    });
+  });
+
+  it('should set the user info for the broadcaster', () => {
+    const actual = userReducer(initialState, setChannelInfo(userState.user));
+    expect(actual.user).toEqual(userState.user);
+  });
+
+  it('should clear the user info for the broadcaster', () => {
+    const actual = userReducer(userState, clearChannelInfo());
+    expect(actual.user).toEqual(initialState.user);
+  });
+
+  it('should set the list of moderators for the broadcaster', () => {
+    const actual = userReducer(initialState, setModerators(userState.moderators));
+    expect(actual.moderators).toEqual(userState.moderators);
+  });
+
+  it('should clear the list of moderators for the broadcaster', () => {
+    const actual = userReducer(userState, clearModerators());
+    expect(actual.moderators).toEqual(initialState.moderators);
+  });
+
+  it('should set the list of VIPs for the broadcaster', () => {
+    const actual = userReducer(initialState, setVIPs(userState.vips));
+    expect(actual.vips).toEqual(userState.vips);
+  });
+
+  it('should clear the list of VIPs for the broadcaster', () => {
+    const actual = userReducer(userState, clearVIPs());
+    expect(actual.vips).toEqual(initialState.vips);
+  });
+});

--- a/src/pages/authenticated-app/authenticated-app.test.jsx
+++ b/src/pages/authenticated-app/authenticated-app.test.jsx
@@ -118,7 +118,7 @@ describe('AuthenticatedApp', () => {
         profile_image_url: 'mockProfileImageUrl',
         auth_pending: false,
         failed_login: false,
-      });
+      }, component.updateModsAndVIPs);
     });
 
     test('should handle response with no user info', () => {
@@ -194,7 +194,7 @@ describe('AuthenticatedApp', () => {
       instance.setState({
         access_token: 'yadayadayada',
         failed_login: false,
-        modList: [],
+        moderators: [],
         username: 'sirgoosewell'
       });
       let component = shallowRenderer.getRenderOutput();

--- a/src/pages/authenticated-app/authenticated-app.test.jsx
+++ b/src/pages/authenticated-app/authenticated-app.test.jsx
@@ -100,8 +100,13 @@ describe('AuthenticatedApp', () => {
 
   describe('onTwitchAuthInit', () => {
     test('should handle response with user info', () => {
-      let component = new AuthenticatedApp();
+      const component = new AuthenticatedApp();
       vi.spyOn(component, 'setState');
+      const props = {
+        setChannelInfo: vi.fn(),
+        setUserInfo: vi.fn(),
+      };
+      component.props = props;
       component.twitchApi = {
         userInfo: {
           login: 'mockUsername',
@@ -111,6 +116,8 @@ describe('AuthenticatedApp', () => {
       };
 
       component.onTwitchAuthInit();
+      expect(props.setUserInfo).toHaveBeenCalledTimes(1);
+      expect(props.setChannelInfo).toHaveBeenCalledTimes(1);
       expect(component.setState).toHaveBeenCalledTimes(1);
       expect(component.setState).toHaveBeenCalledWith({
         username: 'mockUsername',

--- a/src/pages/authenticated-app/index.jsx
+++ b/src/pages/authenticated-app/index.jsx
@@ -9,7 +9,8 @@ import Login from '@/pages/login';
 import TwitchApi from '@/api/twitch';
 import {withRouter, Debounce} from '@/utils';
 import MainScreen from '@/components/main-screen';
-import { setModeratedChannels, } from '@/features/player-queue/user-slice.js';
+import { clearUserInfo, setModeratedChannels, setUserInfo } from '@/features/player-queue/user-slice.js';
+import { clearChannelInfo, clearModerators, clearVIPs, setChannelInfo, setModerators, setVIPs } from '@/features/twitch/channel-slice.js';
 
 const TWITCH_API = new TwitchApi({
   redirectUri: import.meta.env.VITE_APP_REDIRECT_URI_NOENCODE,
@@ -22,12 +23,28 @@ const TWITCH_API = new TwitchApi({
 class AuthenticatedApp extends Component {
   static get propTypes() {
     return {
+      clearChannelInfo: PropTypes.func,
+      clearModerators: PropTypes.func,
+      clearUserInfo: PropTypes.func,
+      clearVIPs: PropTypes.func,
+      setChannelInfo: PropTypes.func,
       setModeratedChannels: PropTypes.func,
+      setModerators: PropTypes.func,
+      setUserInfo: PropTypes.func,
+      setVIPs: PropTypes.func,
     };
   }
   static get defaultProps() {
     return {
-      setModeratedChannels: () => void 0
+      clearChannelInfo: () => void 0,
+      clearModerators: () => void 0,
+      clearUserInfo: () => void 0,
+      clearVIPs: () => void 0,
+      setChannelInfo: () => void 0,
+      setModeratedChannels: () => void 0,
+      setModerators: () => void 0,
+      setUserInfo: () => void 0,
+      setVIPs: () => void 0,
     };
   }
   constructor() {
@@ -64,6 +81,10 @@ class AuthenticatedApp extends Component {
   }
   componentWillUnmount() {
     this._isMounted = false;
+    this.props.clearChannelInfo();
+    this.props.clearModerators();
+    this.props.clearUserInfo();
+    this.props.clearVIPs();
     console.log('authenticated-app - componentWillUnmount');
   }
 
@@ -143,10 +164,11 @@ class AuthenticatedApp extends Component {
         failed_login: true,
       });
     }
+    this.props.setUserInfo(userInfo);
+    this.props.setChannelInfo(userInfo);
     this.setState({
       username: userInfo.login,
       user_id: userInfo.id,
-      // moderators,
       profile_image_url: userInfo.profile_image_url,
       auth_pending: false,
       failed_login: false,
@@ -193,7 +215,7 @@ class AuthenticatedApp extends Component {
         profile_image_url: userInfo.data[0].profile_image_url,
       });
     } catch (e) {
-      console.log('handleUsername: error', e);
+      console.warn('handleUsername: error', e);
       this.logOut();
     }
   };
@@ -223,37 +245,27 @@ class AuthenticatedApp extends Component {
       this.updateVIPs();
       this.updateModeratedChannels();
     } catch (e) {
-      console.log('updateModsAndVIPs: error', e);
+      console.warn('updateModsAndVIPs: error', e);
     }
   };
 
   updateModerators = async() => {
     try {
-      // await this.twitchApi.validateToken();
       const id = this.state.user_id;
-      console.log('updateModerators', {id});
       const moderators = await this.twitchApi.requestModerators(id);
-      console.log({moderators: JSON.stringify(moderators)});
-      this.setState({
-        moderators,
-      });
+      this.props.setModerators(moderators);
     } catch (e) {
-      console.log('updateModerators: error', e);
+      console.warn('updateModerators: error', e);
     }
   };
 
   updateVIPs = async() => {
     try {
-      // await this.twitchApi.validateToken();
       const id = this.state.user_id;
-      console.log('updateVIPs', {id});
       const vips = await this.twitchApi.requestVIPs(id);
-      console.log({vips: JSON.stringify(vips)});
-      this.setState({
-        vips,
-      });
+      this.props.setVIPs(vips);
     } catch (e) {
-      console.log('updateVIPs: error', e);
+      console.warn('updateVIPs: error', e);
     }
   };
 
@@ -307,7 +319,15 @@ class AuthenticatedApp extends Component {
 export {AuthenticatedApp};
 
 const mapDispatchToProps = () => ({
+  clearChannelInfo,
+  clearModerators,
+  clearUserInfo,
+  clearVIPs,
+  setChannelInfo,
   setModeratedChannels,
+  setModerators,
+  setUserInfo,
+  setVIPs,
 });
 export default connect(
   null,

--- a/src/pages/login/__snapshots__/login.test.jsx.snap
+++ b/src/pages/login/__snapshots__/login.test.jsx.snap
@@ -17,7 +17,7 @@ exports[`Login > render > Should render as expected 1`] = `
     </div>
     <a
       class="btn btn-sm fs-2 py-2 px-3 rounded-4"
-      href="https://id.twitch.tv/oauth2/authorize?client_id=VITE_APP_TWITCH_CLIENT_ID&response_type=code&scope=chat:read chat:edit moderation:read user:manage:whispers moderator:read:chatters&redirect_uri=VITE_APP_REDIRECT_URI"
+      href="https://id.twitch.tv/oauth2/authorize?client_id=VITE_APP_TWITCH_CLIENT_ID&response_type=code&scope=chat:read chat:edit moderation:read user:manage:whispers moderator:read:chatters user:read:moderated_channels channel:read:vips channel:read:editors moderator:manage:announcements user:read:subscriptions&redirect_uri=VITE_APP_REDIRECT_URI"
     >
       Log In With 
       <strong>
@@ -77,7 +77,7 @@ exports[`Login > render > Should render with error during development 1`] = `
     </div>
     <a
       class="btn btn-sm fs-2 py-2 px-3 rounded-4"
-      href="https://id.twitch.tv/oauth2/authorize?client_id=VITE_APP_TWITCH_CLIENT_ID&response_type=code&scope=chat:read chat:edit moderation:read user:manage:whispers moderator:read:chatters&redirect_uri=VITE_APP_REDIRECT_URI"
+      href="https://id.twitch.tv/oauth2/authorize?client_id=VITE_APP_TWITCH_CLIENT_ID&response_type=code&scope=chat:read chat:edit moderation:read user:manage:whispers moderator:read:chatters user:read:moderated_channels channel:read:vips channel:read:editors moderator:manage:announcements user:read:subscriptions&redirect_uri=VITE_APP_REDIRECT_URI"
     >
       Log In With 
       <strong>
@@ -137,7 +137,7 @@ exports[`Login > render > Should render without error in production 1`] = `
     </div>
     <a
       class="btn btn-sm fs-2 py-2 px-3 rounded-4"
-      href="https://id.twitch.tv/oauth2/authorize?client_id=VITE_APP_TWITCH_CLIENT_ID&response_type=code&scope=chat:read chat:edit moderation:read user:manage:whispers moderator:read:chatters&redirect_uri=VITE_APP_REDIRECT_URI"
+      href="https://id.twitch.tv/oauth2/authorize?client_id=VITE_APP_TWITCH_CLIENT_ID&response_type=code&scope=chat:read chat:edit moderation:read user:manage:whispers moderator:read:chatters user:read:moderated_channels channel:read:vips channel:read:editors moderator:manage:announcements user:read:subscriptions&redirect_uri=VITE_APP_REDIRECT_URI"
     >
       Log In With 
       <strong>

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -4,7 +4,18 @@ import {version} from '../../../package.json';
 import logo from '@/assets/new-logo.svg';
 import './login.css';
 
-const scopes = 'chat:read chat:edit moderation:read user:manage:whispers moderator:read:chatters';
+const scopes = [
+  'chat:read',
+  'chat:edit',
+  'moderation:read', // https://dev.twitch.tv/docs/api/reference#get-moderators
+  'user:manage:whispers', // https://dev.twitch.tv/docs/api/reference#send-whisper
+  'moderator:read:chatters', // https://dev.twitch.tv/docs/api/reference#get-chatters
+  'user:read:moderated_channels', // https://dev.twitch.tv/docs/api/reference#get-moderated-channels
+  'channel:read:vips', // https://dev.twitch.tv/docs/api/reference#get-vips
+  'channel:read:editors', // https://dev.twitch.tv/docs/api/reference#get-channel-editors
+  'moderator:manage:announcements', // https://dev.twitch.tv/docs/api/reference#send-chat-announcement
+  'user:read:subscriptions', // https://dev.twitch.tv/docs/api/reference#check-user-subscription
+].join(' ');
 
 class Login extends Component {
   constructor() {


### PR DESCRIPTION
Allows Twitch moderators to use the app on one of the channels they moderate, available in a dropdown on the top left. 

Ex: logged in Twitch user dcpesses switches the app to join mattitude1233's channel.
![image](https://github.com/dcpesses/code-whisperer/assets/184237/efb448f8-5274-4ebb-ae4c-e94c242e288f)![image](https://github.com/dcpesses/code-whisperer/assets/184237/9062adff-318d-47ad-a84b-3e1d9b6324ff)

Theoretically it should work as expected, but since there was limited access to other Twitch streams during development, it's been designated as a "Beta Option" under Settings.

![image](https://github.com/dcpesses/code-whisperer/assets/184237/8412390a-dfe9-42e4-92b4-3476821851e3)

Additionally, more component states were migrated to Redux stores.